### PR TITLE
Fix docstring typo for Parallax rotate_view

### DIFF
--- a/Parallax/__init__.py
+++ b/Parallax/__init__.py
@@ -62,7 +62,7 @@ class Parallax:
         pass
 
     def rotate_view(self):
-        '''roates from x, y, z, to n, e, d.'''
+        '''rotates from x, y, z to n, e, d.'''
 
         # unit vector pointing to the source
         self.rad = np.array([np.cos(self.ra.to(u.rad).value) * np.cos(self.dec.to(u.rad).value), 

--- a/ZIPME/Parallax/__init__.py
+++ b/ZIPME/Parallax/__init__.py
@@ -62,7 +62,7 @@ class Parallax:
         pass
 
     def rotate_view(self):
-        '''roates from x, y, z, to n, e, d.'''
+        '''rotates from x, y, z to n, e, d.'''
 
         # unit vector pointing to the source
         self.rad = np.array([np.cos(self.ra.to(u.rad).value) * np.cos(self.dec.to(u.rad).value), 

--- a/trash/gulls_dynesty_post_re_sample.py
+++ b/trash/gulls_dynesty_post_re_sample.py
@@ -182,7 +182,7 @@ class Parallax:
         pass
 
     def rotate_view(self):
-        '''roates from x, y, z, to n, e, d.'''
+        '''rotates from x, y, z to n, e, d.'''
 
         # unit vector pointing to the source
         self.rad = np.array([np.cos(self.ra.rad) * np.cos(self.dec.rad), 


### PR DESCRIPTION
## Summary
- fix spelling of 'rotates' in Parallax rotate_view docstring
- propagate same fix to ZIPME clone and trash script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4f76c22c8328ab460e287b040400