### PR TITLE
Fix east vector comment

### DIFF
--- a/Parallax/__init__.py
+++ b/Parallax/__init__.py
@@ -72,7 +72,7 @@ class Parallax:
         # north vector in x, y, z
         north = np.array([0, 0, 1])
         
-        # unit vector ointing east in the lens plane
+        # unit vector pointing east in the lens plane
         e_unit = np.cross(north, self.rad)/np.linalg.norm(np.cross(north, self.rad))
 
         # unit vector pointing north in the lens plane

--- a/ZIPME/Parallax/__init__.py
+++ b/ZIPME/Parallax/__init__.py
@@ -72,7 +72,7 @@ class Parallax:
         # north vector in x, y, z
         north = np.array([0, 0, 1])
         
-        # unit vector ointing east in the lens plane
+        # unit vector pointing east in the lens plane
         e_unit = np.cross(north, self.rad)/np.linalg.norm(np.cross(north, self.rad))
 
         # unit vector pointing north in the lens plane


### PR DESCRIPTION
## Summary
- fix typos in comments describing east unit vector in the lens plane

## Testing
- `python -m py_compile Parallax/__init__.py ZIPME/Parallax/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_683f507068a88328ad25be88743ea127