### PR TITLE
Fix run_emcee formatting

### DIFF
--- a/Fit/_emcee.py
+++ b/Fit/_emcee.py
@@ -13,7 +13,10 @@ import multiprocessing as mp
 mp.set_start_method('fork', force=True)
 
 
-def run_emcee(self, nl, ndim, stepi, mi, log_prob_function, state, event_obj, truths, prange_linear, prange_log, normal, threads=1, event_name='', path='./', labels=None):
+def run_emcee(
+        self, nl, ndim, stepi, mi, log_prob_function, state,
+        event_obj, truths, prange_linear, prange_log, normal,
+        threads=1, event_name='', path='./', labels=None):
     """
     Edited run_emcee function.
     'bounds' has been replaced by 'prange_linear' and 'prange_log'.


### PR DESCRIPTION
## Summary
- wrap the `run_emcee` definition in `Fit/_emcee.py` so each line is <88 chars

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6d3a3be48328be61210d9c0f8cb3