### PR TITLE
Fix trailing spaces in _emcee

### DIFF
--- a/Fit/_emcee.py
+++ b/Fit/_emcee.py
@@ -47,7 +47,7 @@ def run_emcee(
 
                 steps += stepi
                 count += 1
-                
+
     else:
         # Initialize the sampler with the new arguments
         sampler = emcee.EnsembleSampler(nl, ndim, log_prob_function, args=log_prob_args)
@@ -70,7 +70,7 @@ def run_emcee(
 
             steps += stepi
             count += 1
-    
+
     return sampler
 
 
@@ -84,13 +84,13 @@ def lnprob_transform(self, u, event, true, prange_linear, prange_log, normal=Fal
     for uu in u:
         if not (0.0 <= uu <= 1.0):
             return -np.inf
-            
+
     # Call the new, improved prior_transform with the correct arguments
     theta = self.prior_transform(u, true, prange_linear, prange_log, normal)
-    
+
     # Calculate the log probability (likelihood) with the transformed parameters
     lp = self.lnprob(theta, event)
-        
+
     return lp
 
 


### PR DESCRIPTION
## Summary
- clean up whitespace in `Fit/_emcee.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f6df161748328b5838cd576206337