### PR TITLE
Fix separation spelling and document

### DIFF
--- a/Event/__init__.py
+++ b/Event/__init__.py
@@ -77,14 +77,36 @@ class Event:
         piEE = params[8]
         self.parallax.update_piE_NE(piEN, piEE)
 
-    def projected_seperation(self, i, period, t, phase_offset=0.0, t_start=None, a=1.0):
-        '''Calculate the projected seperation of the binary'''
+    def projected_separation(self, i, period, t, phase_offset=0.0, t_start=None, a=1.0):
+        """Calculate the projected separation of the binary lens.
 
-        # i is the inclination of the orbit in radians
-        # period is the period of the orbit (if t is tau then period is in units of tE)
-        # t is the time relative to t0 (t')
-        # phase_offset is the phase at simulation zero time
-        # a is the semi-major axis of the orbit
+        Parameters
+        ----------
+        i : float or array_like
+            Inclination of the orbit in radians.
+        period : float or array_like
+            Orbital period. If ``t`` is measured in units of ``tE`` then
+            ``period`` must be as well.
+        t : float or array_like
+            Time of evaluation.  If ``t`` is given in units of ``tE`` it should
+            be measured relative to ``t0``.
+        phase_offset : float, optional
+            Phase at ``t_start`` in radians. Default is ``0.0``.
+        t_start : float, optional
+            Reference start time for the orbit. Defaults to ``self.t_ref``.
+        a : float, optional
+            Semimajor axis in units of ``theta_E``. Default is ``1.0``.
+
+        Returns
+        -------
+        s : float or ndarray
+            Projected separation of the two components in the plane of the
+            sky.
+        x : float or ndarray
+            X-coordinate of the secondary relative to the primary.
+        y : float or ndarray
+            Y-coordinate of the secondary relative to the primary.
+        """
 
         if t_start is None:
             t_start = self.t_ref
@@ -166,9 +188,9 @@ class Event:
         #print('debug Event.tref2t0: u0_com: ', u0_com)
         # this is ignoring orital motion
 
-        _, sx_ref, sy_ref = self.projected_seperation(i, period, self.t_ref, phase_offset=phase0, t_start=self.t_ref)
-        s_, sx_t0, sy_t0 = self.projected_seperation(i, period, t0, phase_offset=phase0, t_start=self.t_ref)  
-        _, sx_t0_com, sy_t0_com = self.projected_seperation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)  
+        _, sx_ref, sy_ref = self.projected_separation(i, period, self.t_ref, phase_offset=phase0, t_start=self.t_ref)
+        s_, sx_t0, sy_t0 = self.projected_separation(i, period, t0, phase_offset=phase0, t_start=self.t_ref)
+        _, sx_t0_com, sy_t0_com = self.projected_separation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)
 
         a = s / s_
         rot_ref = np.arctan2(sy_ref, sx_ref)  # again, the size of Sx and Sy are nonsense, but the ratio is valid
@@ -190,7 +212,7 @@ class Event:
         #print('debug Event.tref2t0: alpha_t0_com: ', alpha_t0_com)
         phase0_t0_com = phase0 + (t0_com - self.t_ref) * 2.0 * np.pi / period
 
-        s_com, _, _ = self.projected_seperation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)  
+        s_com, _, _ = self.projected_separation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)
 
 
         truths['params_t0_L1'] = [s, q, rho, u0, alpha, t0, tE, piEE, piEN, i, phase0_t0_L1, period]
@@ -269,7 +291,7 @@ class Event:
 
 
             # Semimajor axis in units of thetaE
-            s_ref, _, _ = self.projected_seperation(i, period, 0.0, phase_offset=phase0, t_start=0.0) 
+            s_ref, _, _ = self.projected_separation(i, period, 0.0, phase_offset=phase0, t_start=0.0)
             a = s/(s_ref)  # angular semimajor axis in uits of thetaE
             #print('debug Event.get_magnification: a/rE:', 
             #      self.truths['Planet_semimajoraxis']/self.truths['rE'], a)
@@ -305,12 +327,12 @@ class Event:
             # this coordinate system is defined at time t_ref with a COM origin
             # let ss be the array of angular lens seperations at each epoch
             # ss does not have a reference frame
-            ss1, x1, y1 = self.projected_seperation(i, period, t, 
+            ss1, x1, y1 = self.projected_separation(i, period, t,
                                                     phase_offset=phase0+np.pi,
                                                     a=a1,
                                                     t_start=t_ref
                                                     )  # star - L1
-            ss2, x2, y2 = self.projected_seperation(i, period, t, 
+            ss2, x2, y2 = self.projected_separation(i, period, t,
                                                     phase_offset=phase0, 
                                                     a=a2, 
                                                     t_start=t_ref
@@ -325,7 +347,7 @@ class Event:
             # Orbital motion - dalphadt
             rot = np.arctan2(y2, x2)  # positions of the planet in the COM-origin, planet-rotation frame
                                     # what is the reference time for this? - currently tref
-            _, x0, y0 = self.projected_seperation(i, period, 0.0, t_start=0.0, phase_offset=phase0, a=a)
+            _, x0, y0 = self.projected_separation(i, period, 0.0, t_start=0.0, phase_offset=phase0, a=a)
             rot0 = np.arctan2(y0, x0)  # at reference time
             # the x, y positions are nonsense wihtout a/a1/a2, but their ratios are valid for the rotation either way
             self.dalpha[obs] = rot - rot0  # saving for debugging

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Plots and posterior samples are saved in the working directory.
 ## Learning more
 
 - Examine `Data.new_event` and `Data.load_data` to understand the light‑curve format.
-- `Event.projected_seperation` describes the source–lens geometry.
+ - `Event.projected_separation` describes the source–lens geometry.
 - `Fit` exposes `run_emcee` and `prior_transform` for controlling MCMC or nested sampling.
 - The included notebooks showcase references and diagnostic plots.
 

--- a/ZIPME/Event/__init__.py
+++ b/ZIPME/Event/__init__.py
@@ -58,14 +58,34 @@ class Event:
         piEE = params[8]
         self.parallax.update_piE_NE(piEN, piEE)
 
-    def projected_seperation(self, i, period, t, phase_offset=0.0, t_start=None, a=1.0):
-        '''Calculate the projected seperation of the binary'''
+    def projected_separation(self, i, period, t, phase_offset=0.0, t_start=None, a=1.0):
+        """Calculate the projected separation of the binary lens.
 
-        # i is the inclination of the orbit in radians
-        # period is the period of the orbit (if t is tau then period is in units of tE)
-        # t is the time relative to t0 (t')
-        # phase_offset is the phase at simulation zero time
-        # a is the semi-major axis of the orbit
+        Parameters
+        ----------
+        i : float or array_like
+            Inclination of the orbit in radians.
+        period : float or array_like
+            Orbital period. If ``t`` is measured in units of ``tE`` then
+            ``period`` must be as well.
+        t : float or array_like
+            Time of evaluation.
+        phase_offset : float, optional
+            Phase at ``t_start`` in radians. Default is ``0.0``.
+        t_start : float, optional
+            Reference start time. Defaults to ``self.t_ref``.
+        a : float, optional
+            Semimajor axis in units of ``theta_E``. Default is ``1.0``.
+
+        Returns
+        -------
+        s : float or ndarray
+            Projected separation between the two components.
+        x : float or ndarray
+            X-coordinate of the secondary relative to the primary.
+        y : float or ndarray
+            Y-coordinate of the secondary relative to the primary.
+        """
 
         if t_start is None:
             t_start = self.t_ref
@@ -147,9 +167,9 @@ class Event:
         #print('debug Event.tref2t0: u0_com: ', u0_com)
         # this is ignoring orital motion
 
-        _, sx_ref, sy_ref = self.projected_seperation(i, period, self.t_ref, phase_offset=phase0, t_start=self.t_ref)
-        s_, sx_t0, sy_t0 = self.projected_seperation(i, period, t0, phase_offset=phase0, t_start=self.t_ref)  
-        _, sx_t0_com, sy_t0_com = self.projected_seperation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)  
+        _, sx_ref, sy_ref = self.projected_separation(i, period, self.t_ref, phase_offset=phase0, t_start=self.t_ref)
+        s_, sx_t0, sy_t0 = self.projected_separation(i, period, t0, phase_offset=phase0, t_start=self.t_ref)
+        _, sx_t0_com, sy_t0_com = self.projected_separation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)
 
         a = s / s_
         rot_ref = np.arctan2(sy_ref, sx_ref)  # again, the size of Sx and Sy are nonsense, but the ratio is valid
@@ -171,7 +191,7 @@ class Event:
         #print('debug Event.tref2t0: alpha_t0_com: ', alpha_t0_com)
         phase0_t0_com = phase0 + (t0_com - self.t_ref) * 2.0 * np.pi / period
 
-        s_com, _, _ = self.projected_seperation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)  
+        s_com, _, _ = self.projected_separation(i, period, t0_com, phase_offset=phase0, t_start=self.t_ref)
 
 
         truths['params_t0_L1'] = [s, q, rho, u0, alpha, t0, tE, piEE, piEN, i, phase0_t0_L1, period]
@@ -242,7 +262,7 @@ class Event:
         s = p[0]  # angular lens seperation at time t0
 
         # Semimajor axis in units of thetaE
-        s_ref, _, _ = self.projected_seperation(i, period, 0.0, phase_offset=phase0, t_start=0.0) 
+        s_ref, _, _ = self.projected_separation(i, period, 0.0, phase_offset=phase0, t_start=0.0)
         a = s/(s_ref)  # angular semimajor axis in uits of thetaE
         #print('debug Event.get_magnification: a/rE:', 
         #      self.truths['Planet_semimajoraxis']/self.truths['rE'], a)
@@ -280,12 +300,12 @@ class Event:
         # this coordinate system is defined at time t_ref with a COM origin
         # let ss be the array of angular lens seperations at each epoch
         # ss does not have a reference frame
-        ss1, x1, y1 = self.projected_seperation(i, period, t, 
+        ss1, x1, y1 = self.projected_separation(i, period, t,
                                                 phase_offset=phase0+np.pi,
                                                 a=a1,
                                                 t_start=t_ref
                                                 )  # star - L1
-        ss2, x2, y2 = self.projected_seperation(i, period, t, 
+        ss2, x2, y2 = self.projected_separation(i, period, t,
                                                 phase_offset=phase0, 
                                                 a=a2, 
                                                 t_start=t_ref
@@ -344,7 +364,7 @@ class Event:
         # Orbital motion - dalphadt
         rot = np.arctan2(y2, x2)  # positions of the planet in the COM-origin, planet-rotation frame
                                   # what is the reference time for this? - currently tref
-        _, x0, y0 = self.projected_seperation(i, period, 0.0, t_start=0.0, phase_offset=phase0, a=a)
+        _, x0, y0 = self.projected_separation(i, period, 0.0, t_start=0.0, phase_offset=phase0, a=a)
         rot0 = np.arctan2(y0, x0)  # at reference time
         # the x, y positions are nonsense wihtout a/a1/a2, but their ratios are valid for the rotation either way
         self.dalpha[obs] = rot - rot0  # saving for debugging

--- a/ZIPME/gulls_post_emcee_wo_pt.py
+++ b/ZIPME/gulls_post_emcee_wo_pt.py
@@ -290,9 +290,9 @@ if __name__ == '__main__':
 
         print('s, q', s, q)
 
-        s_t0, _, _ = event_tc.projected_seperation(i, period, t0, phase_offset=phase0, t_start=t0, a = a)
-        s_tc, _, _ = event_tc.projected_seperation(i, period, tc, phase_offset=phase0, t_start=t0, a = a)
-        s_tref, _, _ = event_tc.projected_seperation(i, period, tc_calc, phase_offset=phase0, t_start=t0, a = a)
+        s_t0, _, _ = event_tc.projected_separation(i, period, t0, phase_offset=phase0, t_start=t0, a = a)
+        s_tc, _, _ = event_tc.projected_separation(i, period, tc, phase_offset=phase0, t_start=t0, a = a)
+        s_tref, _, _ = event_tc.projected_separation(i, period, tc_calc, phase_offset=phase0, t_start=t0, a = a)
         print(s_tc, s_t0, s_tref)
         
         t = event_tc.data[0][0]  # BJD

--- a/gulls_post_emcee_bound_w_pt.py
+++ b/gulls_post_emcee_bound_w_pt.py
@@ -438,7 +438,7 @@ if __name__ == '__main__':
             if LOM_enabled:
                 # Caustic Plot
                 plt.figure()
-                s_tc, _, _ = event_tc.projected_seperation(
+                s_tc, _, _ = event_tc.projected_separation(
                     truths['params'][9],
                     truths['params'][11],
                     truths['tcroin'],

--- a/trash/gulls_dynesty_post_re_sample.py
+++ b/trash/gulls_dynesty_post_re_sample.py
@@ -283,14 +283,32 @@ class Event:
         piEE = params[8]
         self.parallax.update_piE_NE(self, piEN, piEE)
 
-    def projected_seperation(self, i, period, t, phase_offset=0.0, a=1.0):
-        '''Calculate the projected seperation of the binary'''
+    def projected_separation(self, i, period, t, phase_offset=0.0, a=1.0):
+        """Calculate the projected separation of the binary lens.
 
-        # i is the inclination of the orbit in radians
-        # period is the period of the orbit (if t is tau then period is in units of tE)
-        # t is the time relative to t0 (t')
-        # phase_offset is the phase at t0
-        # a is the semi-major axis of the orbit
+        Parameters
+        ----------
+        i : float or array_like
+            Inclination of the orbit in radians.
+        period : float or array_like
+            Orbital period.  If ``t`` is given in units of ``tE`` then
+            ``period`` must be as well.
+        t : float or array_like
+            Time relative to ``t0``.
+        phase_offset : float, optional
+            Initial orbital phase in radians. Default is ``0.0``.
+        a : float, optional
+            Semimajor axis in units of ``theta_E``. Default is ``1.0``.
+
+        Returns
+        -------
+        s : float or ndarray
+            Projected separation of the two components.
+        x : float or ndarray
+            X-coordinate of the secondary relative to the primary.
+        y : float or ndarray
+            Y-coordinate of the secondary relative to the primary.
+        """
 
         phase = 2 * np.pi * (t) / period + phase_offset
         x = a * np.cos(phase)
@@ -315,7 +333,7 @@ class Event:
         phase0 = self.params[10].copy()  # phase at time t0
         period = self.params[11].copy()  # planet orbital period
 
-        s0, _, _ = self.projected_seperation(i, period, 0.0, phase0)
+        s0, _, _ = self.projected_separation(i, period, 0.0, phase0)
         a = s/s0  # semimajor axis in uits of thetaE
 
         a1 = q/(1.0+q) * a
@@ -338,8 +356,8 @@ class Event:
         tau = (t - t0) / tE  # event time in units of tE
 
         # Orbital motion - dsdt
-        s1, x1, y1 = self.projected_seperation(i, period/tE, tau, phase0+np.pi, a1)  # star
-        s2, x2, y2 = self.projected_seperation(i, period/tE, tau, phase0, a2)  # planet
+        s1, x1, y1 = self.projected_separation(i, period/tE, tau, phase0+np.pi, a1)  # star
+        s2, x2, y2 = self.projected_separation(i, period/tE, tau, phase0, a2)  # planet
         ss = np.sqrt((x2 - x1)**2+(y2 - y1)**2)  # i don't know that this is strictly necessary since they are always opposite
         print('debug: s: ', ss, s1+s2)  # these should be equal, I think
 
@@ -438,7 +456,7 @@ def lnlike(theta, event):
 def lnprior(theta, event, bound_penalty=False):
     s, q, rho, u0, alpha, t0, tE, piEE, piEN, i, phase, period = theta
     sinphase = np.sin(phase)
-    s0 = event.projected_seperation(i, period/tE, 0.0, phase)
+    s0 = event.projected_separation(i, period/tE, 0.0, phase)
     if tE > 0.0 and q <= 1.0 and period/tE > 4 and sinphase < 0.9 and sinphase >= 0.00 and i <= np.pi/2 and i >= 0 and s0 > 0.0:
     
         if bound_penalty:   # i'm not using this. I need to redo the calculation


### PR DESCRIPTION
## Summary
- rename method `projected_seperation` -> `projected_separation`
- update all calls to the new method name
- expand the docstring with Numpydoc style
- fix README reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f77d426c08328b025574ed7064a78