### PR TITLE
Improve constructor documentation

### DIFF
--- a/Data/__init__.py
+++ b/Data/__init__.py
@@ -23,6 +23,16 @@ class Data:
     """
 
     def __init__(self):
+        """Create an empty container for event data.
+
+        Notes
+        -----
+        The constructor does not set any attributes or perform I/O.  Side
+        effects are produced when calling :meth:`new_event` which writes the
+        files ``emcee_run_list.txt`` and ``emcee_complete.txt`` in the
+        specified directory.
+        """
+
         pass
 
     def new_event(self, path, sort='alphanumeric'):

--- a/Event/__init__.py
+++ b/Event/__init__.py
@@ -19,33 +19,75 @@ from Orbit import Orbit
 
 
 class Event:
-    """Microlensing event combining data, parallax and orbital effects.
-
-    Parameters
-    ----------
-    parallax : Parallax
-        Object providing parallax calculations.
-    orbit : Orbit
-        Ephemerides for the observatory.
-    data : dict
-        Light curve data keyed by observatory code.
-    truths : dict
-        True parameters for the event.
-    t_start : float
-        Simulation start time in BJD.
-    t_ref : float
-        Reference time for the orbit.
-    eps : float, optional
-        Numerical precision used in the magnification calculations.
-    gamma : float, optional
-        Linear limb darkening coefficient.
-    LOM_enabled : bool, optional
-        If ``True`` enable orbital motion terms in the magnification.
-    """
+    """Microlensing event combining data, parallax and orbital effects."""
 
     from ._VBM import magnification
 
-    def __init__(self, parallax: Parallax, orbit: Orbit, data: dict, truths: dict, t_start: float, t_ref: float, eps=1e-4, gamma=0.36, LOM_enabled=True):
+    def __init__(self, parallax: Parallax, orbit: Orbit, data: dict, truths: dict,
+                 t_start: float, t_ref: float, eps=1e-4, gamma=0.36,
+                 LOM_enabled=True):
+        """Instantiate a microlensing event model.
+
+        Parameters
+        ----------
+        parallax : Parallax
+            Object providing parallax calculations.
+        orbit : Orbit
+            Ephemerides used to locate the observatory.
+        data : dict
+            Light curve data keyed by observatory code.
+        truths : dict
+            Ground truth parameters of the event.  Must contain a ``params``
+            array used to initialise the model.
+        t_start : float
+            Simulation start time in Barycentric Julian Date.
+        t_ref : float
+            Reference time defining the orientation of the parallax frame.
+        eps : float, optional
+            Numerical precision for the magnification calculation.
+        gamma : float, optional
+            Linear limb darkening coefficient.
+        LOM_enabled : bool, optional
+            If ``True`` include lens orbital motion parameters in the model.
+
+        Attributes
+        ----------
+        orbit : Orbit
+            Copy of the provided orbit object.
+        parallax : Parallax
+            Parallax helper configured with ``t_ref``.
+        data : dict
+            Stored light curve data.
+        t_ref : float
+            Reference epoch for parallax calculations.
+        sim_time0 : float
+            Simulation start time in BJD.
+        truths : dict
+            Truth parameters for the event.
+        true_params : array_like
+            Parameter array extracted from ``truths``.
+        params : array_like
+            Current working parameter array.
+        eps : float
+            Precision used by :mod:`_VBM` for integrations.
+        gamma : float
+            Linear limb darkening coefficient.
+        mag_obj : object or None
+            Backend magnification calculator instance.
+        LOM_enabled : bool
+            Flag controlling orbital motion physics.
+        traj_base_tau, traj_parallax_tau, traj_base_beta, traj_parallax_beta
+            Dictionaries used to store trajectory components for each
+            observatory.
+        traj_base_u1, traj_base_u2, traj_parallax_u1, traj_parallax_u2
+            More trajectory diagnostics keyed by observatory.
+        traj_parallax_dalpha_u1, traj_parallax_dalpha_u2
+            Rotated trajectory coordinates.
+        ss, tau, dalpha : dict
+            Storage for separation, scaled time and rotation of the source
+            trajectory.
+        """
+
         self.orbit = orbit
         self.parallax = parallax
         self.parallax.set_ref_frame(t_ref)

--- a/Fit/__init__.py
+++ b/Fit/__init__.py
@@ -57,7 +57,37 @@ class Fit:
     from ._dynesty import prior_transform, runplot, traceplot 
 
     # MODIFIED __init__ to accept and store ndim and labels
-    def __init__(self, sampling_package='emcee', debug=None, LOM_enabled=True, ndim=None, labels=None):
+    def __init__(self, sampling_package='emcee', debug=None, LOM_enabled=True,
+                 ndim=None, labels=None):
+        """Initialise a sampler wrapper.
+
+        Parameters
+        ----------
+        sampling_package : {'emcee', 'dynesty'}, optional
+            Backend used to perform the sampling.
+        debug : list of str or None, optional
+            Strings enabling additional console output.
+        LOM_enabled : bool, optional
+            Include lens orbital motion parameters when ``True``.
+        ndim : int or None, optional
+            Number of parameters in the model.
+        labels : list of str or None, optional
+            Parameter labels used for corner plots.
+
+        Attributes
+        ----------
+        sampling_package : str
+            Name of the chosen sampling backend.
+        debug : list of str
+            Debug keywords stored from ``debug``.
+        LOM_enabled : bool
+            Flag controlling orbital motion physics.
+        ndim : int or None
+            Dimensionality of the parameter space.
+        labels : list of str or None
+            Labels for each parameter.
+        """
+
         if debug is not None:
             self.debug = debug
         else:

--- a/Orbit/__init__.py
+++ b/Orbit/__init__.py
@@ -38,10 +38,24 @@ class Orbit:
         date_format : str, optional
             Format string understood by :class:`~astropy.time.Time`.
 
-        Notes
-        -----
-        The sampled times, positions and velocities are stored on the instance
-        as ``epochs``, ``positions`` and ``velocities`` respectively.
+        Attributes
+        ----------
+        start_time, end_time : :class:`~astropy.time.Time`
+            Parsed representations of ``start_date`` and ``end_date``.
+        n_epochs : int
+            Number of epochs sampled from Horizons.
+        obs_location : str
+            Identifier used in the Horizons query.
+        origin : str
+            Horizons origin code.
+        refplane : str
+            Reference plane of the ephemerides.
+        epochs : :class:`~astropy.time.Time`
+            Sampled times of the ephemeris.
+        positions : :class:`~astropy.coordinates.CartesianRepresentation`
+            Observatory positions at ``epochs``.
+        velocities : :class:`~astropy.coordinates.CartesianDifferential`
+            Observatory velocities at ``epochs``.
         """
 
         self.start_time = Time(start_date, format=date_format)

--- a/Parallax/__init__.py
+++ b/Parallax/__init__.py
@@ -47,6 +47,20 @@ class Parallax:
         epochs : dict, optional
             Dictionary mapping observatory names to the epochs of ``tu``.
 
+        Attributes
+        ----------
+        ra, dec : :class:`astropy.units.Quantity`
+            Coordinates of the microlensing event.
+        orbit : Orbit
+            Observatory ephemerides.
+        tref : float
+            Reference time used to centre the parallax shift.
+        xref, vref : `numpy.ndarray`
+            Observatory position and velocity at ``t_ref``.
+        tu, ne : dict or None
+            Pre-computed shifts in ``(\tau, u)`` and north/east coordinates
+            indexed by observatory name when provided.
+
         Notes
         -----
         When ``tu`` is supplied the shift is immediately converted to north and

--- a/ZIPME/Data/__init__.py
+++ b/ZIPME/Data/__init__.py
@@ -15,6 +15,15 @@ import warnings
 class Data:
 
     def __init__(self):
+        """Create an empty container for event data.
+
+        Notes
+        -----
+        The constructor performs no I/O.  Calls to :meth:`new_event` will
+        create or modify ``emcee_run_list.txt`` and ``emcee_complete.txt`` in
+        the provided directory.
+        """
+
         pass
 
     def new_event(self, path, sort='alphanumeric'):

--- a/ZIPME/Event/__init__.py
+++ b/ZIPME/Event/__init__.py
@@ -20,7 +20,37 @@ class Event:
 
     from ._VBM import magnification
 
-    def __init__(self, parallax: Parallax, orbit: Orbit, data: dict, truths: dict, t_start: float, t_ref: float, eps=1e-4, gamma=0.36):
+    def __init__(self, parallax: Parallax, orbit: Orbit, data: dict, truths: dict,
+                 t_start: float, t_ref: float, eps=1e-4, gamma=0.36):
+        """Instantiate a microlensing event model.
+
+        Parameters
+        ----------
+        parallax : Parallax
+            Parallax helper defining the observer motion.
+        orbit : Orbit
+            Observatory ephemeris used for parallax calculations.
+        data : dict
+            Light curve data keyed by observatory.
+        truths : dict
+            Ground truth parameters for the event containing a ``params``
+            array.
+        t_start : float
+            Start time of the simulation in BJD.
+        t_ref : float
+            Reference epoch for the orbit in BJD.
+        eps : float, optional
+            Numerical precision for magnification evaluation.
+        gamma : float, optional
+            Linear limb darkening coefficient.
+
+        Attributes
+        ----------
+        orbit, parallax, data, t_ref, sim_time0, truths, true_params,
+        params, eps, gamma and ``mag_obj`` correspond to the input arguments
+        and store the current state of the model.
+        """
+
         self.orbit = orbit
         self.parallax = parallax
         self.parallax.set_ref_frame(t_ref)

--- a/ZIPME/Fit/__init__.py
+++ b/ZIPME/Fit/__init__.py
@@ -13,17 +13,34 @@ import multiprocessing as mp
 
 
 class Fit:
-    ''' Fit class doc string '''
+    """Wrapper for fitting microlensing models."""
 
     from ._emcee import run_emcee, lnprob_transform, plot_chain, corner_post
     #from ._dynesty import prior_transform, runplot, traceplot
 
     def __init__(self, sampling_package='emcee', debug=None) -> None:
+        """Initialise the fitting helper.
+
+        Parameters
+        ----------
+        sampling_package : {'emcee', 'dynesty'}, optional
+            Sampler backend to use.
+        debug : list of str or None, optional
+            Keywords enabling verbose output.
+
+        Attributes
+        ----------
+        sampling_package : str
+            Name of the sampling backend.
+        debug : list of str
+            Stored debug keywords.
+        """
+
         if debug is not None:
             self.debug = debug
         else:
             self.debug = []
-    
+
         self.sampling_package = sampling_package
         if sampling_package != 'dynesty' and sampling_package != 'emcee':
             print('Invalid sampling package. Must be dynesty or emcee')

--- a/ZIPME/Orbit/__init__.py
+++ b/ZIPME/Orbit/__init__.py
@@ -8,15 +8,51 @@ from scipy.interpolate import interp1d
 
 class Orbit:
 
-    def __init__(self, 
-                 obs_location='SEMB-L2', 
+    def __init__(self,
+                 obs_location='SEMB-L2',
                  start_date='2018-04-25',
-                 end_date='2023-05-30', 
-                 refplane='ecliptic', 
+                 end_date='2023-05-30',
+                 refplane='ecliptic',
                  n_epochs=None,
                  origin='500@10',
                  date_format='iso'):
-        '''Position file from JPL Horizons'''
+        """Query JPL Horizons for the observatory ephemeris.
+
+        Parameters
+        ----------
+        obs_location : str, optional
+            Horizons identifier of the observatory.
+        start_date, end_date : str, optional
+            Date range to query in the format specified by ``date_format``.
+        refplane : str, optional
+            Reference plane of the returned coordinates.
+        n_epochs : int or None, optional
+            Number of epochs to sample.  Daily cadence is used when ``None``.
+        origin : str, optional
+            Horizons origin code.
+        date_format : str, optional
+            String format for the dates as understood by
+            :class:`~astropy.time.Time`.
+
+        Attributes
+        ----------
+        start_time, end_time : :class:`~astropy.time.Time`
+            Parsed start and end dates.
+        n_epochs : int
+            Number of epochs returned from Horizons.
+        obs_location : str
+            Identifier used in the Horizons query.
+        origin : str
+            Horizons origin code.
+        refplane : str
+            Reference plane of the coordinates.
+        epochs : :class:`~astropy.time.Time`
+            Times of each ephemeris entry.
+        positions : :class:`~astropy.coordinates.CartesianRepresentation`
+            Observatory positions in AU.
+        velocities : :class:`~astropy.coordinates.CartesianDifferential`
+            Observatory velocities in AU/day.
+        """
 
         self.start_time = Time(start_date, format=date_format)
         self.end_time = Time(end_date, format=date_format)

--- a/ZIPME/Parallax/__init__.py
+++ b/ZIPME/Parallax/__init__.py
@@ -7,15 +7,47 @@ from astropy import coordinates as astrocoords
 
 class Parallax:
 
-    def __init__(self, 
-                 ra, 
-                 dec, 
-                 orbit, 
-                 t_ref, 
-                 tu=None, 
-                 piE=None, 
+    def __init__(self,
+                 ra,
+                 dec,
+                 orbit,
+                 t_ref,
+                 tu=None,
+                 piE=None,
                  epochs=None
                  ):
+        """Create a parallax utility object.
+
+        Parameters
+        ----------
+        ra, dec : float
+            Event right ascension and declination in degrees.
+        orbit : Orbit
+            Observatory ephemerides.
+        t_ref : float
+            Reference epoch in BJD.
+        tu : array_like, optional
+            Precomputed parallax shift in ``(\tau, u)`` coordinates.
+        piE : array_like, optional
+            Parallax vector associated with ``tu``.
+        epochs : dict, optional
+            Epochs corresponding to ``tu`` for each observatory.
+
+        Attributes
+        ----------
+        ra, dec : :class:`astropy.units.Quantity`
+            Stored celestial coordinates of the event.
+        orbit : Orbit
+            Ephemeris object used for conversions.
+        tref : float
+            Reference time used for shifts.
+        xref, vref : `numpy.ndarray`
+            Observatory position and velocity at ``t_ref``.
+        tu, ne : dict or None
+            Pre-computed parallax shifts in ``(\tau, u)`` and north/east
+            coordinates when supplied.
+        """
+
         self.ra = ra * u.deg
         self.dec = dec * u.deg
         self.event_coords = astrocoords.SkyCoord(ra=self.ra, dec=self.dec, frame='icrs')


### PR DESCRIPTION
## Summary
- add missing docstring for `Data.__init__`
- document attributes for `Event.__init__`
- add Numpydoc docstring for `Fit.__init__`
- expand attribute documentation in `Orbit.__init__` and `Parallax.__init__`
- update matching modules under `ZIPME`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f850467b883289525de3548679589