### PR TITLE
Use adaptive burn-in before emcee sampling

### DIFF
--- a/Fit/__init__.py
+++ b/Fit/__init__.py
@@ -41,7 +41,13 @@ class Fit:
         Labels corresponding to each model parameter.
     """
 
-    from ._emcee import run_emcee, lnprob_transform, plot_chain, corner_post
+    from ._emcee import (
+        run_emcee,
+        run_burnin,
+        lnprob_transform,
+        plot_chain,
+        corner_post,
+    )
 
     # prior_transform will now be fully defined in _dynesty.py
     # runplot and traceplot are also in _dynesty.py

--- a/gulls_post_emcee_adaptive_BI.py
+++ b/gulls_post_emcee_adaptive_BI.py
@@ -55,6 +55,7 @@ if __name__ == "__main__":
     # Number of steps to discard from the start of the chain when
     # constructing posterior diagnostic plots.
     burnin_steps = 500
+    burnin_max_steps = 1000
 
     if "-f" in sys.argv:
         plot_index = sys.argv.index("-f") + 1
@@ -573,13 +574,32 @@ if __name__ == "__main__":
             LOM_enabled=LOM_enabled,
         )
 
+        state, p_unc, prange_linear, prange_log = fit_obj.run_burnin(
+            nl,
+            ndim,
+            stepi,
+            burnin_max_steps,
+            fit_obj.lnprob_transform,
+            initial_pos,
+            event_fit,
+            truths["params"],
+            prange_linear,
+            prange_log,
+            p_unc,
+            normal,
+            threads=threads,
+            event_name=event_name,
+            path=path,
+            labels=labels,
+        )
+
         sampler = fit_obj.run_emcee(
             nl,
             ndim,
             stepi,
             mi,
             fit_obj.lnprob_transform,
-            initial_pos,
+            state,
             event_fit,
             truths["params"],
             prange_linear,


### PR DESCRIPTION
## Summary
- expose `run_burnin` on `Fit`
- add burn-in step in `gulls_post_emcee_adaptive_BI.py`

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68483fb7eaac83289934b70a8a792727